### PR TITLE
Fixing Tests

### DIFF
--- a/integration-tests/src/test/resources/config-test-child/pom.xml
+++ b/integration-tests/src/test/resources/config-test-child/pom.xml
@@ -15,7 +15,7 @@
             <plugin>
                 <groupId>org.openmrs.maven.plugins</groupId>
                 <artifactId>openmrs-packager-maven-plugin</artifactId>
-                <version>1.7.0-SNAPSHOT</version>
+                <version>1.6.0</version>
                 <executions>
                     <execution>
                         <id>generate-resource-filters</id>

--- a/integration-tests/src/test/resources/config-test-parent/pom.xml
+++ b/integration-tests/src/test/resources/config-test-parent/pom.xml
@@ -14,7 +14,7 @@
             <plugin>
                 <groupId>org.openmrs.maven.plugins</groupId>
                 <artifactId>openmrs-packager-maven-plugin</artifactId>
-                <version>1.7.0-SNAPSHOT</version>
+                <version>1.6.0</version>
                 <executions>
                     <execution>
                         <id>generate-resource-filters</id>


### PR DESCRIPTION
This to fix failing Bamboo tests. The tests expect existing maven artefacts. See [Bamboo logs](https://ci.openmrs.org/browse/CONTRIB-PMP-JOB1-41/log).