### PR TITLE
Update pom.xml to bump initializer-validator version to 2.8.0-SNAPSHOT and update repositories url for child-test-parent pom xml

### DIFF
--- a/integration-tests/src/test/resources/config-test-child/pom.xml
+++ b/integration-tests/src/test/resources/config-test-child/pom.xml
@@ -15,7 +15,7 @@
             <plugin>
                 <groupId>org.openmrs.maven.plugins</groupId>
                 <artifactId>openmrs-packager-maven-plugin</artifactId>
-                <version>1.8.0-SNAPSHOT</version>
+                <version>1.9.0-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <id>generate-resource-filters</id>
@@ -45,5 +45,24 @@
             </plugin>
         </plugins>
     </build>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>openmrs-repo</id>
+            <name>OpenMRS Public Repository</name>
+            <url>https://mavenrepo.openmrs.org/public</url>
+        </pluginRepository>
+        <pluginRepository>
+            <id>openmrs-repo-snapshots</id>
+            <name>OpenMRS Public Repository</name>
+            <url>https://mavenrepo.openmrs.org/snapshots</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </pluginRepository>
+    </pluginRepositories>
 
 </project>

--- a/integration-tests/src/test/resources/config-test-parent/pom.xml
+++ b/integration-tests/src/test/resources/config-test-parent/pom.xml
@@ -14,7 +14,7 @@
             <plugin>
                 <groupId>org.openmrs.maven.plugins</groupId>
                 <artifactId>openmrs-packager-maven-plugin</artifactId>
-                <version>1.8.0-SNAPSHOT</version>
+                <version>1.9.0-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <id>generate-resource-filters</id>
@@ -44,12 +44,20 @@
 
     <pluginRepositories>
         <pluginRepository>
-        <id>openmrs-repo</id>
-        <name>OpenMRS Nexus Repository</name>
-        <url>https://mavenrepo.openmrs.org/nexus/content/repositories/public</url>
-        <snapshots>
-            <enabled>false</enabled>
-        </snapshots>
+            <id>openmrs-repo</id>
+            <name>OpenMRS Public Repository</name>
+            <url>https://mavenrepo.openmrs.org/public</url>
+        </pluginRepository>
+        <pluginRepository>
+            <id>openmrs-repo-snapshots</id>
+            <name>OpenMRS Public Repository</name>
+            <url>https://mavenrepo.openmrs.org/snapshots</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
         </pluginRepository>
     </pluginRepositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
 		<dependency>
 			<groupId>org.openmrs.module</groupId>
 			<artifactId>initializer-validator</artifactId>
-			<version>2.7.0</version>
+			<version>2.8.0-SNAPSHOT</version>
 		</dependency>
 
 		<!-- For reading YAML and JSON files -->
@@ -191,6 +191,11 @@
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
+		</repository>
+		<repository>
+			<id>mks-repo</id>
+			<name>Mekom Solutions Maven repository</name>
+			<url>https://nexus.mekomsolutions.net/repository/maven-public</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
- Update parent pom to use initializer-validator: 2.8.0-SNAPSHOT and respective repository uri
- Update config-test-parent/pom.xml pluginrepositories
- Update config-test-child/pom.xml pluginrepositories