### PR TITLE
Bump initializer-validator version to 2.9.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
 		<dependency>
 			<groupId>org.openmrs.module</groupId>
 			<artifactId>initializer-validator</artifactId>
-			<version>2.8.0-SNAPSHOT</version>
+			<version>2.9.0-SNAPSHOT</version>
 		</dependency>
 
 		<!-- For reading YAML and JSON files -->


### PR DESCRIPTION
This PR upgrades Iniz Validator to a more updated version including new domain and validation features.